### PR TITLE
Add cache-control to s3 docs

### DIFF
--- a/.github/workflows/s3-deploy.yml.example
+++ b/.github/workflows/s3-deploy.yml.example
@@ -36,7 +36,7 @@ jobs:
           aws-region: eu-west-2
       - name: Deploy to S3
         run: |
-          aws s3 sync _site s3://${{ secrets.AWS_BUCKET_NAME }} --delete
+          aws s3 sync _site s3://${{ secrets.AWS_BUCKET_NAME }} --delete --cache-control max-age=300
       - name: Invalidate CloudFront Cache
         run: |
           aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You can manually build and deploy the site from your local machine using the fol
 
 ```bash
 JEKYLL_ENV=production bundle exec jekyll build
-aws s3 sync _site s3://bucket-name --delete --profile my-profile
+aws s3 sync _site s3://bucket-name --delete --cache-control max-age=300 --profile my-profile
 ```
 
 ### Deploying using GitHub Actions


### PR DESCRIPTION
Set [cache control](https://docs.aws.amazon.com/whitepapers/latest/build-static-websites-aws/controlling-how-long-amazon-s3-content-is-cached-by-amazon-cloudfront.html#specify-cache-control-headers) meta data to files in S3 bucket. 