### PR TITLE
Increase padding around smaller links to make them easier to click

### DIFF
--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -1,8 +1,8 @@
-<ul class="flex justify-start my-8">
+<ul class="flex justify-start my-4">
   <li class="mr-2">
     <a
       href="{{ site.baseurl }}/"
-      class="text-sm text-action-500 underline flex flex-nowrap items-center hover:decoration-dotted"
+      class="text-sm text-action-500 underline flex flex-nowrap items-center hover:decoration-dotted py-4"
       ><span class="mr-2">Home</span>
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -24,7 +24,7 @@
     <li class="mr-2">
       <a
         href="{{ site.baseurl }}{{ breadcrumb.link}}"
-        class="text-sm text-action-500 underline flex flex-nowrap items-center hover:decoration-dotted"
+        class="text-sm text-action-500 underline flex flex-nowrap items-center hover:decoration-dotted py-4"
         ><span class="mr-2">{{ breadcrumb.name }}</span>
         {% if forloop.last == false %}
           <svg

--- a/_includes/cookie-banner.html
+++ b/_includes/cookie-banner.html
@@ -12,7 +12,7 @@
       By clicking the Accept button, you agree to us doing so. More info on our
       <a
         href="{{ site.baseurl }}/cookie-policy/"
-        class="text-action-500 underline hover:text-action-900 hover:decoration-dotted"
+        class="text-action-500 underline hover:text-action-900 hover:decoration-dotted py-2"
         >cookie policy</a
       >
     </p>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -20,7 +20,7 @@
       <div class="grow"></div>
       <div>
         {% if site.copyright_url != '' %}
-          <a href="{{ site.copyright_link }}" class="hover:underline">&copy; {{ site.copyright_name }}</a>
+          <a href="{{ site.copyright_link }}" class="hover:underline py-4">&copy; {{ site.copyright_name }}</a>
         {% else %}
           <p>&copy; {{ site.copyright_name }}</p>
         {% endif %}

--- a/_includes/phase-banner.html
+++ b/_includes/phase-banner.html
@@ -7,7 +7,7 @@
       >This is a new service - your
       <a
         href="{{ site.phase_link }}"
-        class="text-action-500 underline hover:decoration-dotted hover:text-action-900"
+        class="text-action-500 underline hover:decoration-dotted hover:text-action-900 py-2"
         >feedback</a
       >
       will help us to improve it.</span

--- a/_includes/post-card.html
+++ b/_includes/post-card.html
@@ -10,7 +10,7 @@
   {% endif %}
   <div class="p-4">
     <h3>
-      <a href="{{ post.url }}" class="underline hover:decoration-dotted flex">{{ post.title }}</a>
+      <a href="{{ post.url }}" class="underline hover:decoration-dotted flex py-2">{{ post.title }}</a>
     </h3>
     <p class="my-2">Published: {{ post.date | date: '%b %-d, %Y' }}</p>
     <div class="prose prose-sm">{{ post.excerpt }}</div>

--- a/_includes/related-links.html
+++ b/_includes/related-links.html
@@ -1,12 +1,12 @@
 <ul class="list-disc list-inside">
   {% for item in site.data.[page.related] %}
-    <li class="pb-2">
+    <li class="pb-1">
       {% if page.url == item.link %}
-        <span>{{ item.name }}</span>
+        <span class="inline-block py-2">{{ item.name }}</span>
       {% else %}
         <a
           href="{{ item.link }}"
-          class="text-action-500 hover:underline py-2 underline hover:decoration-dotted hover:text-action-900"
+          class="text-action-500 hover:underline py-2 underline hover:decoration-dotted hover:text-action-900 inline-block"
         >
           {{- item.name -}}
         </a>


### PR DESCRIPTION
To help make the site more accessible, the smaller links now have additional vertical padding to make the links easier to click.

Take a look at the [Tailwind documentation for padding](https://tailwindcss.com/docs/padding) for more information on how `py-` works. 

## Testing
- Checkout this branch and run `bundle exec jekyll serve` to bring up a local version
- Visit `http://localhost:4000` and manually test the site, checking the links are now larger and easier to click on. 