### PR TITLE
Allow embedding TikTok videos

### DIFF
--- a/_data/component_sections.yml
+++ b/_data/component_sections.yml
@@ -32,7 +32,7 @@
       summary: Add an alert banner to every page on the site
     - name: Video
       link: /components/video/
-      summary: Embed a YouTube video
+      summary: Embed a YouTube or TikTok video
     - name: Warning text
       link: /components/warning-text
       summary: Warning text that stands out from standard content

--- a/_includes/video.html
+++ b/_includes/video.html
@@ -7,7 +7,7 @@
       aria-label="{{ include.label }}"
     >
     </iframe>
-  {% else %}
+  {% elsif include.vimeo %}
     <iframe
       src="https://player.vimeo.com/video/{{ include.vimeo }}?color=ff9933&title=0&byline=0&portrait=0"
       frameborder="0"
@@ -16,5 +16,12 @@
       aria-label="{{ include.label }}"
     ></iframe>
     <script src="https://player.vimeo.com/api/player.js"></script>
+  {% elsif include.tiktok %}
+    <iframe
+      src="https://www.tiktok.com/player/v1/{{ include.tiktok }}?controls=1&rel=0&autoplay=0"
+      aria-label="{{ include.label }}"
+    ></iframe>
+  {% else %}
+    <p>Video not supported.</p>
   {% endif %}
 </div>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -54,3 +54,7 @@
 .skip-link:active {
   @apply bg-yellow-500 block static text-black p-4 w-auto h-auto overflow-visible underline;
 }
+
+blockquote.tiktok-embed {
+  border-left: none;
+}

--- a/components/video.md
+++ b/components/video.md
@@ -9,6 +9,8 @@ breadcrumbs:
 
 A video component can be used to embed a video, with the benefit of it keeping a responsive 16 by 9 ratio.
 
+## YouTube
+
 You can include a YouTube video as follows, passing in the video id and the descriptive label:
 
 {% raw %}
@@ -22,3 +24,19 @@ You can include a YouTube video as follows, passing in the video id and the desc
 This will output the following:
 
 {% include video.html youtube="NUmT9pboY5s" label="Northampton bike park" %}
+
+## TikTok
+
+You can include a TikTok video as follows, passing in the video id and the descriptive label:
+
+{% raw %}
+
+```liquid
+{% include video.html tiktok="7390064283612106016" label="Northampton market square" %}
+```
+
+{% endraw %}
+
+This will output the following:
+
+{% include video.html tiktok="7390064283612106016" label="Northampton market square" %}


### PR DESCRIPTION
This uses TikTok's embedded player: https://developers.tiktok.com/doc/embed-player/

## Testing
- Checkout this branch and run `bundle install` then `bundle exec jekyll serve`
- Visit `http://localhost:4000/components/video/` and test that the embedded TikTok video displays and plays when you press the play button.
- It should not autoplay and any related videos shown at the end (if any) should be from the same author.